### PR TITLE
fix PatchMetadata function

### DIFF
--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -139,13 +139,13 @@ func (c *Client) UpdateCertificate(data CertificateData) error {
 		if err != nil {
 			return fmt.Errorf("while writing payload to vault: %w", err)
 		}
-		err = c.patchMetadata(fullSecretPath, data.VaultPath)
+		err = c.patchMetadata(data.VaultPath)
 		return err
 	}
 	return nil
 }
 
-func (c *Client) patchMetadata(fullSecretPath, vaultPath string) error {
+func (c *Client) patchMetadata(vaultPath string) error {
 	t := time.Now().Add(365 * 24 * time.Hour)
 	date := fmt.Sprintf("%d-%02d-%02d", t.Year(), t.Month(), t.Day())
 	customMetadata := map[string]interface{}{
@@ -158,7 +158,7 @@ func (c *Client) patchMetadata(fullSecretPath, vaultPath string) error {
 		"username":                "UNLINKED",
 	}
 
-	err := c.client.KVv2(fullSecretPath).PatchMetadata(context.TODO(), vaultPath, vaultapi.KVMetadataPatchInput{
+	err := c.client.KVv2(c.Options.KVEngineName).PatchMetadata(context.TODO(), vaultPath, vaultapi.KVMetadataPatchInput{
 		CustomMetadata: customMetadata,
 	})
 	return err

--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"reflect"
 	"sync"
 	"time"
@@ -117,7 +116,7 @@ func (c *Client) UpdateCertificate(data CertificateData) error {
 		return err
 	}
 
-	fullSecretPath := path.Join(c.Options.KVEngineName, "data", data.VaultPath)
+	fullSecretPath := c.secretPath(data.VaultPath)
 	payload := map[string]interface{}{ // this exact type is necessary because we do reflect.DeepEqual() below!
 		"certificate": string(data.CertBytes),
 		"private-key": string(data.KeyBytes),
@@ -140,13 +139,13 @@ func (c *Client) UpdateCertificate(data CertificateData) error {
 		if err != nil {
 			return fmt.Errorf("while writing payload to vault: %w", err)
 		}
-		err = c.patchMetadata(fullSecretPath)
+		err = c.patchMetadata(fullSecretPath, data.VaultPath)
 		return err
 	}
 	return nil
 }
 
-func (c *Client) patchMetadata(fullSecretPath string) error {
+func (c *Client) patchMetadata(fullSecretPath, vaultPath string) error {
 	t := time.Now().Add(365 * 24 * time.Hour)
 	date := fmt.Sprintf("%d-%02d-%02d", t.Year(), t.Month(), t.Day())
 	customMetadata := map[string]interface{}{
@@ -159,8 +158,12 @@ func (c *Client) patchMetadata(fullSecretPath string) error {
 		"username":                "UNLINKED",
 	}
 
-	err := c.client.KVv2(fullSecretPath).PatchMetadata(context.TODO(), fullSecretPath, vaultapi.KVMetadataPatchInput{
+	err := c.client.KVv2(fullSecretPath).PatchMetadata(context.TODO(), vaultPath, vaultapi.KVMetadataPatchInput{
 		CustomMetadata: customMetadata,
 	})
 	return err
+}
+
+func (c *Client) secretPath(filePath string) string {
+	return fmt.Sprintf("%s/data/%s", c.Options.KVEngineName, filePath)
 }


### PR DESCRIPTION
only pass the `data.VaultPath` when patching metadata and not the `fullSecretPath` which has already a format `%s/data/%s`.

`client.KVv2(...).PatchMetadata` is calculating the metadata path here:
https://github.com/hashicorp/vault/blob/b4d07277a6c5318bb50d3b94bbd6135dccb4c601/api/kv_v2.go#L270-L271